### PR TITLE
Textblobfix

### DIFF
--- a/awe_components/components/utility_functions.py
+++ b/awe_components/components/utility_functions.py
@@ -3384,6 +3384,16 @@ def AWE_Info(document: Doc,
             raise AWE_Workbench_Error(
                 'Invalid indicator ' + indicator)                   
 
+        # QUICK FIX: spacytextblob no longer references polarity, subjectivity, 
+        # nor assessments via doc._.X, but rather doc._.blob.X
+        # We are quickly fixing this problem in AWE_Info
+        if indicator == "polarity":
+            indicator = "blob.polarity"
+        elif indicator == "subjectivity":
+            indicator = "blob.subjectivity"
+        elif indicator == "assessments":
+            indicator = "blob.assessments"
+
         if infoType == 'Doc':
             baseInfo = createSpanInfo(indicator,
                                       document)

--- a/awe_components/components/utility_functions.py
+++ b/awe_components/components/utility_functions.py
@@ -2899,6 +2899,9 @@ def setTokenEntry(name, token, value):
     # attribute.                          #
     # TBD: put security check in for this #
     #######################################
+    elif "blob" in name:
+        name = name.replace("blob.", "")
+        entry['value'] = getattr(token._.blob, name)
     elif token.has_extension(name):
         # TODO: Use Token.get_extension
         # https://spacy.io/api/token

--- a/awe_components/components/viewpointFeatures.py
+++ b/awe_components/components/viewpointFeatures.py
@@ -4636,15 +4636,15 @@ class ViewpointFeatureDef:
             # neutral.
             if tok._.vwp_evaluation \
                or tok._.vwp_hedge \
-               or tok.text in doc._.assessments:
-                if tok._.polarity < 0 or tok._.sentiword < 0:
-                    tok._.vwp_tone_ = min(tok._.polarity, tok._.sentiword)
-                elif tok._.polarity > 0 and tok._.sentiword > 0:
-                    tok._.vwp_tone_ = max(tok._.polarity, tok._.sentiword)
+               or tok.text in doc._.blob.sentiment_assessments.assessments:
+                if tok._.blob.sentiment_assessments.polarity < 0 or tok._.sentiword < 0:
+                    tok._.vwp_tone_ = min(tok._.sentiment_assessments.polarity, tok._.sentiword)
+                elif tok._.sentiment_assessments.polarity > 0 and tok._.sentiword > 0:
+                    tok._.vwp_tone_ = max(tok._.sentiment_assessments.polarity, tok._.sentiword)
                 else:
-                    tok._.vwp_tone_ = (tok._.polarity + tok._.sentiword) / 2
+                    tok._.vwp_tone_ = (tok._.sentiment_assessments.polarity + tok._.sentiword) / 2
             else:
-                tok._.vwp_tone_ = min(tok._.polarity, tok._.sentiword)
+                tok._.vwp_tone_ = min(tok._.sentiment_assessments.polarity, tok._.sentiword)
 
             # rule order fixes to the tone variable are generally a bad idea,
             # but these are so common that fixing them gets rid of a lot of

--- a/awe_components/components/viewpointFeatures.py
+++ b/awe_components/components/viewpointFeatures.py
@@ -4638,13 +4638,13 @@ class ViewpointFeatureDef:
                or tok._.vwp_hedge \
                or tok.text in doc._.blob.sentiment_assessments.assessments:
                 if tok._.blob.sentiment_assessments.polarity < 0 or tok._.sentiword < 0:
-                    tok._.vwp_tone_ = min(tok._.sentiment_assessments.polarity, tok._.sentiword)
-                elif tok._.sentiment_assessments.polarity > 0 and tok._.sentiword > 0:
-                    tok._.vwp_tone_ = max(tok._.sentiment_assessments.polarity, tok._.sentiword)
+                    tok._.vwp_tone_ = min(tok._.blob.sentiment_assessments.polarity, tok._.sentiword)
+                elif tok._.blob.sentiment_assessments.polarity > 0 and tok._.sentiword > 0:
+                    tok._.vwp_tone_ = max(tok._.blob.sentiment_assessments.polarity, tok._.sentiword)
                 else:
-                    tok._.vwp_tone_ = (tok._.sentiment_assessments.polarity + tok._.sentiword) / 2
+                    tok._.vwp_tone_ = (tok._.blob.sentiment_assessments.polarity + tok._.sentiword) / 2
             else:
-                tok._.vwp_tone_ = min(tok._.sentiment_assessments.polarity, tok._.sentiword)
+                tok._.vwp_tone_ = min(tok._.blob.sentiment_assessments.polarity, tok._.sentiword)
 
             # rule order fixes to the tone variable are generally a bad idea,
             # but these are so common that fixing them gets rid of a lot of

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
   coreferee
   rdflib
   spacytextblob
-  numpy
+  numpy==1.26.4
   srsly
   wordfreq
   statistics

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ python_requires = >=3.9
 cmdclass =
   install = install.AWEInstall
 install_requires =
-  awe_lexica
+  awe_lexica @ git+https://github.com/ArgLab/AWE_Lexica.git
   spacy
   holmes_extractor
   coreferee

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ python_requires = >=3.9
 cmdclass =
   install = install.AWEInstall
 install_requires =
-  awe_lexica @ git+https://github.com/ArgLab/AWE_Lexica.git@varname-patch
+  awe_lexica @ git+https://github.com/ArgLab/AWE_Lexica.git
   spacy
   coreferee
   rdflib

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ python_requires = >=3.9
 cmdclass =
   install = install.AWEInstall
 install_requires =
-  awe_lexica @ git+https://github.com/ArgLab/AWE_Lexica.git
+  awe_lexica @ git+https://github.com/ArgLab/AWE_Lexica.git@varname-patch
   spacy
   coreferee
   rdflib


### PR DESCRIPTION
with newer versions of spacy, spacytextblob no longer references document/token features the same way; namely, the new convention is X._.blob.Y instead of X._.Y.

These fixes should bring spacytextblob usage up to current. However, there is a little "hack" fix for utility functions, which assumes that the former nomenclature for referencing spacytextblob still remains the same. I added some conditionals/replacements to checking indicators so that referencing "blob" is included and valid.